### PR TITLE
fix: timeline의 정렬 방법 수정

### DIFF
--- a/backend/src/main/java/com/linkflix/api/service/TimelineServiceImpl.java
+++ b/backend/src/main/java/com/linkflix/api/service/TimelineServiceImpl.java
@@ -44,7 +44,8 @@ public class TimelineServiceImpl implements TimelineService{
        Collections.sort(timelineRes, new Comparator<TimelineRes>() {
            @Override
            public int compare(TimelineRes o1, TimelineRes o2) {
-               return o1.getStartTime().compareTo(o2.getStartTime());
+               int num = o1.getStartTime().length() - o2.getStartTime().length();
+               return num == 0 ? o1.getStartTime().compareTo(o2.getStartTime()) : o1.getStartTime().length() - o2.getStartTime().length();
            }
        });
 


### PR DESCRIPTION
타임라인 리스트에서 각각의 시간을 담고 있는 변수의 길이로 판단 후,
변수의 길이가 같으면 시간이 먼저인 순으로 리스트 정렬하여 반환